### PR TITLE
Remove link to issues from pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,12 +17,6 @@ PR Metadata
 ### Description
 <!--- Describe your changes in detail -->
 
-### Related GitHub [Issues](../issues) and/or ClickUp Task(s)
-<!--- This project only accepts pull requests related to open GitHub Issues or ClickUp task(s) -->
-<!--- If suggesting a new feature or change, please discuss it in a GitHub issue or ClickUp task first -->
-<!--- If fixing a bug, there should be a GitHub issue or ClickUp task describing it with steps to reproduce -->
-<!--- Please link to the GitHub issue and/or ClickUp task here: -->
-
 ### Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@ PR Metadata
 
 ### Description
 <!--- Describe your changes in detail -->
+<!--- If there are other links relevant to this PR, mention them here as well -->
 
 ### Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->


### PR DESCRIPTION
### Description
Remove the section asking to link GitHub or ClickUp task.

### Related GitHub [Issues](../issues) and/or ClickUp Task(s)
n/a

### Motivation and Context
We have an integration on ClickUp to do this automatically.

### How Has This Been Tested?
n/a

### Checklist
<!--- Put an `x` in the boxes that apply. -->

- [x] Have you filled the sections above?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same GitHub Issues/ClickUp Task(s)?
- [x] Have you documented the changes in GitHub Issues and/or ClickUp Task(s) related to this Pull Request?
- [x] Have you added labels, where appropriate, to this Pull Request?

### Screenshot 
n/a