### PR TITLE
Remove screenshot subsection from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,8 @@ PR Metadata
 - [ ] Have you documented the changes in GitHub Issues and/or ClickUp Task(s) related to this Pull Request?
 - [ ] Have you added labels, where appropriate, to this Pull Request?
 
-### Screenshot 
-<!--- Include any relevant screenshot. -->
-<!-- Don't upload confidential images. Images in GitHub Issues will be accessible from everyone outside DeepX-inc. -->
+<!--
+Do not include screenshots.
+- These will be accessible from everyone outside DeepX-inc.
+- Add them to the ClickUp task instead.
+-->

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ## Important Notice
 
-This repository is public.
-* **Do not commit any sensitive information**. Commit changes can be viewed by third parties.
-* This includes links to other internal tools (e.g. ClickUp, Lucidchart, Google Docs, etc.)
+**Do not commit any sensitive information**
+
+* This repository is public.
+* Commit changes can be viewed by third parties.
+* Do not include links to our internal tools (e.g. ClickUp, Lucidchart, Google Docs, etc.)
 
 ## Overview
 


### PR DESCRIPTION
<!---
Pull Request Template
- Please fill the sections below as described in the comments.
- This information simplifies collaboration and helps future readers.
- Reviewers should ask for this info to be filled when missing.
-->

### Description
- Remove subsection about screenshots. These should be added in clickup.
- Update security notice in the README.

### Motivation and Context
- Cleanup template.

### How Has This Been Tested?
n/a

### Checklist
n/a
