### PR TITLE
Simplify the PR template with a guidelines document 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,37 +1,17 @@
-<!---
-Pull Request Template
-- Please fill the sections below as described in the comments.
-- This information simplifies collaboration and helps future readers.
-- Reviewers should ask for this info to be filled when missing.
--->
-
-<!---
-PR Metadata
-- Title: Provide a short summary of the PR changes.
-- Assignees: Assign yourself and other direct collaborators.
-- Type: Create the PR as a draft. Only set it to non-draft when it is ready to be reviewed.
-- Reviewers: Only assign reviewers when the PR is ready to be reviewed.
-- Labels: Only assign labels with high priority and important context. Default is label-less.
+<!--
+- Please fill the sections below and the PR metadata.
+- Make it readable to reviewers and future visitors.
 -->
 
 ### Description
 <!--- Describe your changes in detail -->
-<!--- If there are other links relevant to this PR, mention them here as well -->
 
 ### Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 
 ### How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Readers can use this info to verify or try the changes. -->
-<!--- - Code snippet with the commands you used to test this locally. -->
-<!--- - Link to relevant CI run. -->
-<!--- - Other useful info for reviewers, you can include screenshots here. -->
+<!--- Help reviewers by providing explanations, code snippets, checklists, etc. -->
 
-### Checklist
-<!--- Put an `x` in the boxes that apply. -->
+---
 
-- [ ] Have you filled the sections above?
-- [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same GitHub Issues/ClickUp Task(s)?
-- [ ] Have you documented the changes in GitHub Issues and/or ClickUp Task(s) related to this Pull Request?
-- [ ] Have you added labels, where appropriate, to this Pull Request?
+- [PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 - Please fill the sections below and the PR metadata.
-- Make it readable to reviewers and future visitors.
+- Make it readable for reviewers and future visitors.
 -->
 
 ### Description

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -1,0 +1,69 @@
+# PR Guidelines
+
+Making your PR stand-out.
+
+This guide supports the [PR Template](./.github/pull_request_template.md) used for all DeepX repositories.
+
+Having a readable PR is critical to speed-up reviewing and support future readers.
+
+As a reviewer, please ask for the template to be filled.
+
+## PR Metadata
+
+Setting PR metadata:
+
+- Title:
+    - Provide a short summary of the PR changes.
+    - Do not include the clickup ID in the title.
+- Assignees:
+    - Assign yourself and other direct collaborators.
+- Type:
+    - Create the PR as a draft.
+    - Only set it to non-draft when it is ready to be reviewed. Avoid spam.
+- Reviewers:
+    - Only assign reviewers when the PR is ready to be reviewed. Avoid spam.
+- Labels:
+    - Make wise use of the labels.
+    - In particular, remember to tag `breaking` changes or PRs to `do not merge`.
+
+## PR Description
+
+### Description
+
+Describe your changes in detail.
+
+If the description gets too big, you can use H4 subsections `####`.
+
+Remember to mention other relevant PRs.
+- For example, PRs that this one depends on.
+- When mentioning PRs, we recommend using the this format `- #123` in a new line. This will expand the PR to show its title and status. For example:
+- #3
+
+### Motivation and Context
+
+Explain why is this change required and what problem does it solve.
+
+### How Has This Been Tested?
+
+Describe in detail how you tested your changes.
+
+Reviewers can use this to try the changes locally.
+
+#### Pro-Tip: Create a checklist of validations
+
+This will help you keep track of pending validations, and will reassure the reviewer that you actually performed those.
+
+For example:
+- [x] Verify that all markdown links work. 
+- [x] Verify that the system builds.
+- [ ] Verify with Acceptance Test suite locally.
+
+#### Pro-Tip: Use code-snippets to show how you tested it
+
+I verified the system works running this test:
+```bash
+cd /root/code/tests/
+pytest-3 test_my_library.py
+```
+
+Use [syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) for the [available languages](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml).

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -4,7 +4,7 @@ Making your PR stand-out.
 
 This guide supports the [PR Template](./.github/pull_request_template.md) used by all DeepX repositories.
 
-Having a readable PR is critical to speed-up reviewing and support future readers.
+Having a readable PR is critical to speed-up the review process and to support future readers.
 
 As a reviewer, please ask for the template to be filled.
 

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -41,7 +41,7 @@ Remember to mention other relevant PRs.
 
 ### Motivation and Context
 
-Explain why is this change required and what problem does it solve.
+Explain why this change is required and what problem it solves.
 
 ### How Has This Been Tested?
 

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -2,7 +2,7 @@
 
 Making your PR stand-out.
 
-This guide supports the [PR Template](./.github/pull_request_template.md) used for all DeepX repositories.
+This guide supports the [PR Template](./.github/pull_request_template.md) used by all DeepX repositories.
 
 Having a readable PR is critical to speed-up reviewing and support future readers.
 

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -32,7 +32,7 @@ Setting PR metadata:
 
 Describe your changes in detail.
 
-If the description gets too big, you can use H4 subsections `####`.
+If the description gets too big you can use H4 subsections `####`.
 
 Remember to mention other relevant PRs.
 - For example, PRs that this one depends on.

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -24,7 +24,7 @@ Setting PR metadata:
     - Only assign reviewers when the PR is ready to be reviewed to avoid spam.
 - Labels:
     - Make wise use of the labels.
-    - In particular, remember to tag `breaking` changes or PRs to `do not merge`.
+    - In particular, remember to tag `breaking` changes or PRs with `do not merge` labels.
 
 ## PR Description
 

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -19,7 +19,7 @@ Setting PR metadata:
     - Assign yourself and other direct collaborators.
 - Type:
     - Create the PR as a draft.
-    - Only set it to non-draft when it is ready to be reviewed. Avoid spam.
+    - Only set it to non-draft when it is ready to be reviewed to avoid spam.
 - Reviewers:
     - Only assign reviewers when the PR is ready to be reviewed. Avoid spam.
 - Labels:

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -36,7 +36,7 @@ If the description gets too big, you can use H4 subsections `####`.
 
 Remember to mention other relevant PRs.
 - For example, PRs that this one depends on.
-- When mentioning PRs, we recommend using the this format `- #123` in a new line. This will expand the PR to show its title and status. For example:
+- When mentioning PRs, we recommend using the following format: `- #123` in a new line. This will expand the PR to show its title and status. For example:
 - #3
 
 ### Motivation and Context

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -60,7 +60,7 @@ For example:
 
 #### Pro-Tip: Use code-snippets to show how you tested it
 
-I verified the system works running this test:
+I verified that the system works by running this test:
 ```bash
 cd /root/code/tests/
 pytest-3 test_my_library.py

--- a/pull_request_guidelines.md
+++ b/pull_request_guidelines.md
@@ -21,7 +21,7 @@ Setting PR metadata:
     - Create the PR as a draft.
     - Only set it to non-draft when it is ready to be reviewed to avoid spam.
 - Reviewers:
-    - Only assign reviewers when the PR is ready to be reviewed. Avoid spam.
+    - Only assign reviewers when the PR is ready to be reviewed to avoid spam.
 - Labels:
     - Make wise use of the labels.
     - In particular, remember to tag `breaking` changes or PRs to `do not merge`.


### PR DESCRIPTION
### Description

- Cleaned up the PR template to reduce so much noise.
  - Reduce the size of comments `<!-- -->`.
  - Remove the checklist (useless).
- Added a separate document with guidelines and clarifications.
- Make the PR template include a link to the guidelines.

### Motivation and Context
Every new PR includes too much noise from the template.

With this change, I aim to:
- Reduce the frustration of having to delete so many comments from the template.
- Promote better PRs using a separate document.

### How Has This Been Tested?
Not tested.
