### PR TITLE
Add a link to the Google Code Review Guidelines in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,4 @@
 
 - [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
 - [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
+- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,5 @@
 <br>
 ---
 
-- [PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md)
+- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
+- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/reviewer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,4 @@
 ---
 
 - [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
-- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/reviewer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
+- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).


### PR DESCRIPTION
### Description

- Add a link to the Google Reviewing guidelines, including quick access links for reviewers and authors.
- Clarify the scope of DeepX guidelines.

### Motivation and Context
Google Code Review guidelines (https://google.github.io/eng-practices/) are well-written and cover critical aspects for authors and reviewers in detail.

### How Has This Been Tested?

Markdown viewer.

<br>
---

- [PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md)
